### PR TITLE
Upgrade salesforce API version to 39.0

### DIFF
--- a/lib/salesforce_bulk_api.rb
+++ b/lib/salesforce_bulk_api.rb
@@ -42,11 +42,12 @@ module SalesforceBulkApi
     def query_async(sobject, query, options={})
       batch_size = options.fetch(:batch_size, 10000)
       timeout = options.fetch(:timeout, 1500)
+      operation = options.fetch(:operation, 'query')
 
       count :query
 
       job = SalesforceBulkApi::Job.new(
-          operation: :query,
+          operation: operation,
           sobject: sobject,
           records: query,
           external_field: nil,

--- a/lib/salesforce_bulk_api/connection.rb
+++ b/lib/salesforce_bulk_api/connection.rb
@@ -6,7 +6,7 @@ require 'timeout'
     attr_reader :api_version
 
     LOGIN_HOST = 'login.salesforce.com'
-    DEFAULT_API_VERSION = '38.0'.freeze
+    DEFAULT_API_VERSION = '39.0'.freeze
 
     def initialize(client)
       @client = client

--- a/lib/salesforce_bulk_api/job.rb
+++ b/lib/salesforce_bulk_api/job.rb
@@ -220,9 +220,9 @@ module SalesforceBulkApi
 
       response = @connection.get_request(nil, path, headers)
       response_parsed = XmlSimple.xml_in(response)
-      results = response_parsed['result'] unless @operation == 'query'
+      results = response_parsed['result'] unless @operation == 'query' || @operation == 'queryAll'
 
-      if(@operation == 'query') # The query op requires us to do another request to get the results
+      if(@operation == 'query' || @operation == 'queryAll') # The query op requires us to do another request to get the results
         result_id = response_parsed["result"][0]
         path = "job/#{@job_id}/batch/#{batch_id}/result/#{result_id}"
         headers = Hash.new

--- a/lib/salesforce_bulk_api/version.rb
+++ b/lib/salesforce_bulk_api/version.rb
@@ -1,3 +1,3 @@
 module SalesforceBulkApi
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end


### PR DESCRIPTION
- Upgrade Salesforce API version to 39.0
- Enables `queryAll` in Bulk API

[Use Bulk Query | Bulk API Developer Guide | Salesforce Developers](https://developer.salesforce.com/docs/atlas.en-us.206.0.api_asynch.meta/api_asynch/asynch_api_using_bulk_query.htm)